### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ test/
 *.log
 .glsignore
 dist/
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ test/
 .glsignore
 dist/
 .idea
+.DS_Store


### PR DESCRIPTION
* `.idea/` is added to .gitignore. It is added because of the JetBrains IDEs.

Signed-off-by: Gökhan Özeloğlu <gokhan.ozeloglu@deliveryhero.com>