### PR TITLE
first stable version v1.0.0 for go package registry

### DIFF
--- a/internal/info/constants.go
+++ b/internal/info/constants.go
@@ -3,10 +3,12 @@ package info
 import "fmt"
 
 const (
-	Project = "gls"
-	Version = "0.1.1"
+	Project      = "gls"
+	VersionMajor = 1
+	VersionMinor = 0
+	VersionPatch = 0
 )
 
 func ProjectNameWithVersion() string {
-	return fmt.Sprintf("%s v%s", Project, Version)
+	return fmt.Sprintf("%s v%d.%d.%d", Project, VersionMajor, VersionMinor, VersionPatch)
 }


### PR DESCRIPTION
## Summary

Go package registry requires a stable release with major version number >= 1. This PR is intended to apply the semantic versioning to `gls` and update the version to `v1.0.0`, the first stable version.