### PR TITLE
Concurrent walk optimization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gdamore/tcell/v2 v2.5.1
 	github.com/h2non/filetype v1.1.3
 	github.com/rivo/tview v0.0.0-20220703182358-a13d901d3386
+	golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/rivo/tview v0.0.0-20220703182358-a13d901d3386 h1:Mi1WlPy6SDxnhljPcE4z
 github.com/rivo/tview v0.0.0-20220703182358-a13d901d3386/go.mod h1:WIfMkQNY+oq/mWwtsjOYHIZBuwthioY2srOmljJkTnk=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0 h1:cu5kTvlzcw1Q5S9f5ip1/cpiB4nXvw1XYzFPGgzLUOY=
+golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210309074719-68d13333faf2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220318055525-2edf467146b5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/fs/tree_builder_test.go
+++ b/internal/fs/tree_builder_test.go
@@ -12,7 +12,6 @@ var (
 
 func BenchmarkFileTreeBuilder(b *testing.B) {
 	fmt.Printf("path: %s\n", *path)
-	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		bl := NewFileTreeBuilder(*path)
 		if err := bl.Build(); err != nil {

--- a/internal/fs/tree_builder_test.go
+++ b/internal/fs/tree_builder_test.go
@@ -2,7 +2,6 @@ package fs
 
 import (
 	"flag"
-	"fmt"
 	"testing"
 )
 
@@ -11,7 +10,6 @@ var (
 )
 
 func BenchmarkFileTreeBuilder(b *testing.B) {
-	fmt.Printf("path: %s\n", *path)
 	for i := 0; i < b.N; i++ {
 		bl := NewFileTreeBuilder(*path)
 		if err := bl.Build(); err != nil {

--- a/internal/fs/tree_builder_test.go
+++ b/internal/fs/tree_builder_test.go
@@ -12,6 +12,7 @@ var (
 
 func BenchmarkFileTreeBuilder(b *testing.B) {
 	fmt.Printf("path: %s\n", *path)
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		bl := NewFileTreeBuilder(*path)
 		if err := bl.Build(); err != nil {

--- a/internal/fs/walk.go
+++ b/internal/fs/walk.go
@@ -1,15 +1,19 @@
 package fs
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sort"
+	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/ozansz/gls/internal"
 	"github.com/ozansz/gls/internal/local"
 	"github.com/ozansz/gls/internal/types"
 	"github.com/ozansz/gls/log"
+	"golang.org/x/sync/errgroup"
 )
 
 type WalkOptions struct {
@@ -41,26 +45,44 @@ func Walk(path string, opts *WalkOptions) (*types.Node, error) {
 			log.Warningf("%s: %v", path, err)
 			return root, nil
 		}
+
+		eg, _ := errgroup.WithContext(context.Background())
+		rl := &sync.Mutex{}
+
 		for _, name := range names {
-			child, err := Walk(path+"/"+name, opts)
-			if err != nil {
-				return nil, err
-			}
-			child.Parent = root
-			root.Size += child.Size
-			root.SizeOnDisk += child.SizeOnDisk
-			threshOK := child.Size >= opts.SizeThreshold
-			ignoreOK := true
-			if opts.IgnoreChecker != nil && opts.IgnoreChecker.ShouldIgnore(child.Name, child.IsDir) {
-				ignoreOK = false
-			}
-			if !ignoreOK {
-				log.Debugf("ignore: %s", path+"/"+child.Name)
-			}
-			if threshOK && ignoreOK {
-				root.Children = append(root.Children, child)
-			}
+			var curr = name
+			eg.Go(func() error {
+				child, err := Walk(path+"/"+curr, opts)
+				if err != nil {
+					return err
+				}
+				child.Parent = root
+				rl.Lock()
+				root.Size += child.Size
+				root.SizeOnDisk += child.SizeOnDisk
+				threshOK := child.Size >= opts.SizeThreshold
+				ignoreOK := true
+				if opts.IgnoreChecker != nil && opts.IgnoreChecker.ShouldIgnore(child.Name, child.IsDir) {
+					ignoreOK = false
+				}
+				if !ignoreOK {
+					log.Debugf("ignore: %s", path+"/"+child.Name)
+				}
+				if threshOK && ignoreOK {
+					root.Children = append(root.Children, child)
+				}
+				rl.Unlock()
+				return nil
+			})
 		}
+
+		if err := eg.Wait(); err != nil {
+			return nil, err
+		}
+
+		sort.Slice(root.Children, func(i, j int) bool {
+			return strings.Compare(root.Children[i].Name, root.Children[j].Name) == -1
+		})
 	}
 	return root, nil
 }
@@ -76,6 +98,5 @@ func readDirNames(dirname string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	sort.Strings(names)
 	return names, nil
 }

--- a/internal/fs/walk.go
+++ b/internal/fs/walk.go
@@ -58,6 +58,7 @@ func Walk(path string, opts *WalkOptions) (*types.Node, error) {
 				}
 				child.Parent = root
 				rl.Lock()
+				defer rl.Unlock()
 				root.Size += child.Size
 				root.SizeOnDisk += child.SizeOnDisk
 				threshOK := child.Size >= opts.SizeThreshold
@@ -71,7 +72,6 @@ func Walk(path string, opts *WalkOptions) (*types.Node, error) {
 				if threshOK && ignoreOK {
 					root.Children = append(root.Children, child)
 				}
-				rl.Unlock()
 				return nil
 			})
 		}


### PR DESCRIPTION
## Summary

Use `golang.org/x/sync/errgroup` to perform concurrent directory traversal / listing.  

Fixes #17 

### Impact

Please delete options that are not relevant.

- [x] Performance improvement for file listing

### Testing

**Test Configuration**:
* Go version: `1.18`
* Hardware: `I7 6700HQ, 16Gb Memory DDR4, SSD`
* Operating system: `Linux 5.10.146-1-MANJARO x86_64 GNU/Linux`


### Benchmarks 

```name               old time/op    new time/op    delta
FileTreeBuilder-8     2.65s ± 9%     2.31s ± 4%  -12.95%  (p=0.000 n=10+10)

name               old alloc/op   new alloc/op   delta
FileTreeBuilder-8     297MB ± 0%     297MB ± 0%     ~     (p=0.280 n=10+10)

name               old allocs/op  new allocs/op  delta
FileTreeBuilder-8     3.00M ± 0%     3.00M ± 0%   -0.00%  (p=0.007 n=10+10)
```

