### PR TITLE
Customize color palette with `.glsrc` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,28 @@ in the project directory.
 
 In addition, if you think that your configurations or other changes seem necessary to improve the project, your contributions will be welcomed :)
 
+### Customize color palette
+
+You can customize the color palette with `.glsrc` file.  The only thing you need to do is create a `.glsrc` file in `$HOME`
+directory and set the colors as key-value pairs. An example is below:
+
+```text
+GridTitleColor=blue
+TreeViewTitleColor=yellow
+FileInfoTitleColor=lightgreen
+DirectoryColor=red
+BorderColor=white
+FileInfoAttrColor=orange
+FileInfoValueColor=pink
+SearchFormTitleColor=brown
+UnmarkedFileColor=deeppink
+MarkedFileColor=gray
+FileInfoTabAttrWidth=30
+```
+
+When you run the program, the color palette values are overridden with values in `.glsrc` file. The file must be stored in 
+`$HOME` directory and the file name must be `.glsrc`. Otherwise, the program uses the default color palette values.  
+
 ### Command line arguments
 
 ```bash

--- a/gui/constants.go
+++ b/gui/constants.go
@@ -2,6 +2,10 @@ package gui
 
 import (
 	"github.com/gdamore/tcell/v2"
+	"log"
+	"os"
+	"strconv"
+	"strings"
 )
 
 type Shortcut struct {
@@ -9,7 +13,7 @@ type Shortcut struct {
 	Command string
 }
 
-const (
+var (
 	GridTitleColor       = tcell.ColorRed
 	TreeViewTitleColor   = tcell.ColorGreen
 	FileInfoTitleColor   = tcell.ColorOrange
@@ -88,3 +92,69 @@ var (
 		},
 	}
 )
+
+func init() {
+	dirname, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatalf("HOME directory couldn't get")
+	}
+	path := dirname + "/.glsrc"
+	err = readGLSRCFile(path)
+	if err != nil {
+		return
+	}
+}
+
+// readGLSRCFile reads .glsrc file and updates the variables.
+func readGLSRCFile(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	customVars := strings.Split(string(data), "\n")
+	for _, v := range customVars {
+		if len(strings.TrimSpace(v)) == 0 {
+			continue
+		}
+		vv := strings.Split(v, "=")
+		key, val := strings.TrimSpace(vv[0]), strings.TrimSpace(vv[1])
+		if strings.EqualFold(key, "GridTitleColor") {
+			GridTitleColor = tcell.GetColor(val)
+		}
+		if strings.EqualFold(key, "TreeViewTitleColor") {
+			TreeViewTitleColor = tcell.GetColor(val)
+		}
+		if strings.EqualFold(key, "FileInfoTitleColor") {
+			FileInfoTitleColor = tcell.GetColor(val)
+		}
+		if strings.EqualFold(key, "DirectoryColor") {
+			DirectoryColor = tcell.GetColor(val)
+		}
+		if strings.EqualFold(key, "BorderColor") {
+			BorderColor = tcell.GetColor(val)
+		}
+		if strings.EqualFold(key, "FileInfoAttrColor") {
+			FileInfoAttrColor = tcell.GetColor(val)
+		}
+		if strings.EqualFold(key, "FileInfoValueColor") {
+			FileInfoValueColor = tcell.GetColor(val)
+		}
+		if strings.EqualFold(key, "SearchFormTitleColor") {
+			SearchFormTitleColor = tcell.GetColor(val)
+		}
+		if strings.EqualFold(key, "UnmarkedFileColor") {
+			UnmarkedFileColor = tcell.GetColor(val)
+		}
+		if strings.EqualFold(key, "MarkedFileColor") {
+			MarkedFileColor = tcell.GetColor(val)
+		}
+		if strings.EqualFold(key, "FileInfoTabAttrWidth") {
+			fileInfoTabAttrWidth, err := strconv.Atoi(val)
+			if err != nil {
+				continue
+			}
+			FileInfoTabAttrWidth = fileInfoTabAttrWidth
+		}
+	}
+	return nil
+}

--- a/gui/constants.go
+++ b/gui/constants.go
@@ -13,6 +13,8 @@ type Shortcut struct {
 	Command string
 }
 
+const configurationFile = ".glsrc"
+
 var (
 	GridTitleColor       = tcell.ColorRed
 	TreeViewTitleColor   = tcell.ColorGreen
@@ -98,7 +100,7 @@ func init() {
 	if err != nil {
 		log.Fatalf("HOME directory couldn't get")
 	}
-	path := dirname + "/.glsrc"
+	path := dirname + "/" + configurationFile
 	err = readGLSRCFile(path)
 	if err != nil {
 		return

--- a/gui/constants_test.go
+++ b/gui/constants_test.go
@@ -1,0 +1,157 @@
+package gui
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"testing"
+)
+
+func TestReadGLSRCFile(t *testing.T) {
+	testCases := []struct {
+		name    string
+		path    string
+		expVars map[any]any
+		expErr  bool
+	}{
+		{
+			name: "Non-exist .glsrc file",
+			path: "./testdata/non_exist_glsrc",
+			expVars: map[any]any{
+				GridTitleColor:       tcell.ColorRed,
+				TreeViewTitleColor:   tcell.ColorGreen,
+				FileInfoTitleColor:   tcell.ColorOrange,
+				DirectoryColor:       tcell.ColorTurquoise,
+				BorderColor:          tcell.ColorLightGray,
+				FileInfoAttrColor:    tcell.ColorPowderBlue,
+				FileInfoValueColor:   tcell.ColorLightSkyBlue,
+				SearchFormTitleColor: tcell.ColorLightSkyBlue,
+				UnmarkedFileColor:    tcell.ColorWhite,
+				MarkedFileColor:      tcell.ColorRed,
+				FileInfoTabAttrWidth: 20,
+			},
+			expErr: true,
+		},
+		{
+			name: "Customize variables",
+			path: "./testdata/.glsrc_test1",
+			expVars: map[any]any{
+				GridTitleColor:       tcell.ColorBlue,
+				TreeViewTitleColor:   tcell.ColorYellow,
+				FileInfoTitleColor:   tcell.ColorLightGreen,
+				DirectoryColor:       tcell.ColorRed,
+				BorderColor:          tcell.ColorWhite,
+				FileInfoAttrColor:    tcell.ColorOrange,
+				FileInfoValueColor:   tcell.ColorPink,
+				SearchFormTitleColor: tcell.ColorBrown,
+				UnmarkedFileColor:    tcell.ColorDeepPink,
+				MarkedFileColor:      tcell.ColorGray,
+				FileInfoTabAttrWidth: 30,
+			},
+		},
+		{
+			name: "Some empty lines and mixed-case keys",
+			path: "./testdata/.glsrc_test2",
+			expVars: map[any]any{
+				GridTitleColor:       tcell.ColorBlue,
+				TreeViewTitleColor:   tcell.ColorPink,
+				FileInfoTitleColor:   tcell.ColorOrange,
+				DirectoryColor:       tcell.ColorTurquoise,
+				BorderColor:          tcell.ColorLightGray,
+				FileInfoAttrColor:    tcell.ColorPowderBlue,
+				FileInfoValueColor:   tcell.ColorLightSkyBlue,
+				SearchFormTitleColor: tcell.ColorLightSkyBlue,
+				UnmarkedFileColor:    tcell.ColorWhite,
+				MarkedFileColor:      tcell.ColorRed,
+				FileInfoTabAttrWidth: 20,
+			},
+		},
+		{
+			name: "Unexpected key and values",
+			path: "./testdata/.glsrc_test3",
+			expVars: map[any]any{
+				GridTitleColor:       tcell.ColorRed,
+				TreeViewTitleColor:   tcell.ColorGreen,
+				FileInfoTitleColor:   tcell.ColorOrange,
+				DirectoryColor:       tcell.ColorTurquoise,
+				BorderColor:          tcell.ColorLightGray,
+				FileInfoAttrColor:    tcell.ColorPowderBlue,
+				FileInfoValueColor:   tcell.ColorLightSkyBlue,
+				SearchFormTitleColor: tcell.ColorLightSkyBlue,
+				UnmarkedFileColor:    tcell.ColorWhite,
+				MarkedFileColor:      tcell.ColorRed,
+				FileInfoTabAttrWidth: 20,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := readGLSRCFile(tc.path)
+			if tc.expErr {
+				if err == nil {
+					t.Fatal("error expected, but error is nil")
+				}
+				t.Log("error:", err)
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			for key, val := range tc.expVars {
+				if ok, v := checkVal(key, val); !ok {
+					t.Fatalf("expected %v, got %v", val, v)
+				}
+			}
+		})
+	}
+}
+
+// checkVal checks the given val whether it is expected val.
+func checkVal(key any, val any) (bool, any) {
+	switch key {
+	case "GridTitleColor":
+		if GridTitleColor != val {
+			return false, GridTitleColor
+		}
+	case "TreeViewTitleColor":
+		if TreeViewTitleColor != val {
+			return false, TreeViewTitleColor
+		}
+	case "FileInfoTitleColor":
+		if FileInfoTitleColor != val {
+			return false, FileInfoTitleColor
+		}
+	case "DirectoryColor":
+		if DirectoryColor != val {
+			return false, DirectoryColor
+		}
+	case "BorderColor":
+		if BorderColor != val {
+			return false, BorderColor
+		}
+	case "FileInfoAttrColor":
+		if FileInfoAttrColor != val {
+			return false, FileInfoAttrColor
+		}
+	case "FileInfoValueColor":
+		if FileInfoValueColor != val {
+			return false, FileInfoValueColor
+		}
+	case "SearchFormTitleColor":
+		if SearchFormTitleColor != val {
+			return false, SearchFormTitleColor
+		}
+	case "UnmarkedFileColor":
+		if UnmarkedFileColor != val {
+			return false, UnmarkedFileColor
+		}
+	case "MarkedFileColor":
+		if MarkedFileColor != val {
+			return false, MarkedFileColor
+		}
+	case "FileInfoTabAttrWidth":
+		if FileInfoTabAttrWidth != val {
+			return false, FileInfoTabAttrWidth
+		}
+	}
+	return true, nil
+}

--- a/gui/testdata/.glsrc_test1
+++ b/gui/testdata/.glsrc_test1
@@ -1,0 +1,11 @@
+GridTitleColor=blue
+TreeViewTitleColor=yellow
+FileInfoTitleColor=lightgreen
+DirectoryColor=red
+BorderColor=white
+FileInfoAttrColor=orange
+FileInfoValueColor=pink
+SearchFormTitleColor=brown
+UnmarkedFileColor=deeppink
+MarkedFileColor=gray
+FileInfoTabAttrWidth=30

--- a/gui/testdata/.glsrc_test2
+++ b/gui/testdata/.glsrc_test2
@@ -1,0 +1,4 @@
+gridtitlecolor=blue
+
+
+TreeviewtitleColor    =    pink

--- a/gui/testdata/.glsrc_test3
+++ b/gui/testdata/.glsrc_test3
@@ -1,0 +1,3 @@
+unexpectedKey=blue
+TreeViewTitleColor=reddd
+FileInfoTabAttrWidth=wrong_val


### PR DESCRIPTION
* `readGLSRCFile` function added. This function reads and overrides the vars.
* Test data added.
* Tests added.
* README updated.

Signed-off-by: Gökhan Özeloğlu <gokhan.ozeloglu@deliveryhero.com>

## Summary

Fixes #16

I added a new feature for customizing the color palette by `.glsrc` file. 

### Impact

- [x] New feature (backward compatible change which adds functionality)

### Testing

Tests are using `testdata` under the `gui` directory. There is no special instruction to run the tests. 

**Test Configuration**:
* Go version:  `go1.18.2 darwin/amd64`
* Hardware: `MBP 2019 16 GB RAM 2,3 GHz 8-Core Intel Core i9 DDR4`
* Operating system: `macOS Monterey`