### PR TITLE
Add VIM integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,24 +73,24 @@ gls -nogui -path ~/Documents
 
 ### TUI shortcuts
 
-| Shortcut           | Command            | Description                                                                                                                                                                |
-| ------------------ | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `q`, `ESC`, `ˆC`        | quit               | Exits the program                                                                                                                                                          |
-| `c`                  | collapse           | Collapses all nodes in the file tree view                                                                                                                                  |
-| `e`                  | expand             | Expands all nodes in the file tree view                                                                                                                                    |
-| `s`                  | search             | Opens modal to search nodes (files and folders) by name                                                                                                                    |
-| `r`                  | regex search       | Same as search, but you can search using regular expressions                                                                                                               |
+| Shortcut           | Command            | Description                                                                                                                                                                    |
+| ------------------ |--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `q`, `ESC`, `ˆC`        | quit               | Exits the program                                                                                                                                                              |
+| `c`                  | collapse           | Collapses all nodes in the file tree view                                                                                                                                      |
+| `e`                  | expand             | Expands all nodes in the file tree view                                                                                                                                        |
+| `s`                  | search             | Opens modal to search nodes (files and folders) by name                                                                                                                        |
+| `r`                  | regex search       | Same as search, but you can search using regular expressions                                                                                                                   |
 | `x`                  | restore            | Loads the original file tree view, mostly used after `search` and `regex search`                                                                                               |
-| `o`                  | open               | Opens the selected (on hover) file/folder with the default program                                                                                                         |
-| `p`                  | open               | Opens modal to specify the executable path which will be used to open the selected (on hover) file/folder                                                                  |
-| `BACKSPACE` , `DEL`    | remove             | Removes the selected (on hover) file. Folder removal is currently not supported                                                                                            |
+| `o`                  | open               | Opens the selected (on hover) file/folder with the default program                                                                                                             |
+| `p`                  | open               | Opens modal to specify the executable path which will be used to open the selected (on hover) file/folder                                                                      |
+| `BACKSPACE` , `DEL`    | remove             | Removes the selected (on hover) file. Folder removal is currently not supported                                                                                                |
 | `m`                  | mark               | Marks/unmarks the selected (on hover) file or folder. Marked nodes can be used later for `duplicate` and `move`                                                                |
-| `u`                  | unmark             | Unmarks all the marked files and folders                                                                                                                                   |
+| `u`                  | unmark             | Unmarks all the marked files and folders                                                                                                                                       |
 | `n`                  | new                | Create and (optionally) open file **(will be available in next update)**                                                                                                       |
 | `d`                  | duplicate          | Copy/pastes the marked files and folders to a specified destination. The destination is specified by the text input of the opened modal **(will be available in next update)** |
-| `v`                  | move               | Moves the marked files and folders to a specified destination. The destination is specified by the text input of the opened modal **(will be available in next update)**       |
-| `TAB`, `SPACE`, `ENTER`  | toggle expand node | Expands the node if currently collapsed, and vice versa, the selected (on hover) file or folder                                                                            |
-| `ARROW KEYS`, `SCROLL` | navigate           | Navigates between nodes in the file tree view                                                                                                                              |
+| `v`                  | open file in vim   | Opens file in VIM editor.                                                                                                                                                      |
+| `TAB`, `SPACE`, `ENTER`  | toggle expand node | Expands the node if currently collapsed, and vice versa, the selected (on hover) file or folder                                                                                |
+| `ARROW KEYS`, `SCROLL` | navigate           | Navigates between nodes in the file tree view                                                                                                                                  |
 
 ### Configuration
 

--- a/gui/constants.go
+++ b/gui/constants.go
@@ -92,6 +92,10 @@ var (
 			Key:     "n",
 			Command: "create new file",
 		},
+		{
+			Key:     "v",
+			Command: "open file in VIM",
+		},
 	}
 )
 

--- a/gui/core.go
+++ b/gui/core.go
@@ -2,6 +2,8 @@ package gui
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
 	"time"
 
 	"github.com/gdamore/tcell/v2"
@@ -60,6 +62,9 @@ func GetApp(path string, f types.SizeFormatter) *tview.Application {
 			}
 			if event.Rune() == 'n' || event.Rune() == 'N' {
 				createNewFile(app)
+			}
+			if event.Rune() == 'v' || event.Rune() == 'V' {
+				openVIM(app)
 			}
 			// Commands below here are about the current hovered file.
 			if currTreeView == nil {
@@ -515,4 +520,18 @@ func createNewFile(app *tview.Application) {
 		})
 	isFormInputActive = true
 	app.SetRoot(form, true).SetFocus(form)
+}
+
+// openVIM opens the file in VIM editor.
+func openVIM(app *tview.Application) {
+	cNode := currTreeView.GetCurrentNode()
+	path := cNode.GetReference().(*types.Node).RelativePath(currPath)
+	app.Suspend(func() {
+		cmd := exec.Command("vim", path)
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		if err := cmd.Run(); err != nil {
+			log.Error(err)
+		}
+	})
 }


### PR DESCRIPTION
* Files can be opened in the VIM editor.
* `README` updated.

Signed-off-by: Gökhan Özeloğlu <gokhan.ozeloglu@deliveryhero.com>

## Summary
Fixes #6

I added VIM integration. Files can be opened up in VIM editor. 

### Impact

Please delete options that are not relevant.

- [x] New feature (backward compatible change which adds functionality)

### Testing

Tested manually. Works well. 

**Test Configuration**:
* Go version: `go1.18.2 darwin/amd64`
* Hardware: `MBP 2019 16 GB RAM 2,3 GHz 8-Core Intel Core i9 DDR4`
* Operating system: `macOS Monterey`