### PR TITLE
Add GoReleaser-Homebrew integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,3 +35,28 @@ jobs:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           # GitHub sets this automatically
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+brews:
+  -
+    name: gls
+    tap:
+      owner: ozansz
+      name: homebrew-gls
+
+    url_template: "https://github.com/ozansz/gls/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+
+    commit_msg_template: "Brew formula update for gls version {{ .Tag }}"
+
+    # Folder inside the repository to put the formula.
+    # Default is the root folder.
+    folder: Formula
+
+    homepage: "https://github.com/ozansz/gls"
+
+    description: "Minimal file manager with terminal UI."
+
+    license: "MIT"


### PR DESCRIPTION
Signed-off-by: Gökhan Özeloğlu <gokhan.ozeloglu@deliveryhero.com>

## Summary

Fixes #1 

I added Homebrew integration to GoReleaser. 

### Next step

❗You need to create a repository name as `homebrew-gls` and add a `Formula` folder in this repository. If you don't want to put Ruby files in the `Formula` folder, I can modify the PR and GoReleaser Bot will put files in the root. 

### Impact

Please delete options that are not relevant.

- [x] New feature (backward compatible change which adds functionality)

### Testing

Couldn't test on the local machine. 