### PR TITLE
Added new workflow for building .deb packages and the checksum for Debian-based GNU/Linux distros

### DIFF
--- a/.github/workflows/deb-package.yml
+++ b/.github/workflows/deb-package.yml
@@ -1,0 +1,48 @@
+name: Build .deb package and create checksum
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      
+      - name: Build binaries
+        run: go build -v ./...
+      
+      - name: Prepare directories for .deb packaging
+        run: |
+          mkdir gls
+          mkdir -p gls/usr/local/bin
+          cp gls gls/usr/local/bin
+          
+      - name: Build .deb package
+        uses: jiro4989/build-deb-action@v2
+        with:
+          package: gls
+          package_root: gls
+          maintainer: Ozan Sazak <ozan.sazak@protonmail.ch>
+          version: ${{ github.ref }} # refs/tags/v*.*.*
+          arch: 'amd64'
+          desc: 'minimal file manager with terminal UI #Go'
+
+      - name: Checksum of package
+        run: |
+          sha256sum gls_*.deb > $(ls gls_*.deb).sha256sum
+          echo gls_*.deb.sha256sum
+      
+      - name: Release
+        uses: softprops/action-gh-release@v0.1.14
+        with:
+          files: |
+            *.deb*

--- a/.github/workflows/deb-package.yml
+++ b/.github/workflows/deb-package.yml
@@ -18,19 +18,19 @@ jobs:
           go-version: 1.19
       
       - name: Build binaries
-        run: go build -v ./...
+        run: go build -v ./... && go build -v cmd/gls.go
       
       - name: Prepare directories for .deb packaging
         run: |
-          mkdir gls
-          mkdir -p gls/usr/local/bin
-          cp gls gls/usr/local/bin
+          mkdir gls-deb
+          mkdir -p gls-deb/usr/local/bin
+          cp gls gls-deb/usr/local/bin
           
       - name: Build .deb package
         uses: jiro4989/build-deb-action@v2
         with:
           package: gls
-          package_root: gls
+          package_root: gls-deb
           maintainer: Ozan Sazak <ozan.sazak@protonmail.ch>
           version: ${{ github.ref }} # refs/tags/v*.*.*
           arch: 'amd64'


### PR DESCRIPTION
## Summary

> Please list the summary of your changes in the codebase about the related issue here. Please also include the context of your changes, and required next steps if there are any.

* I designed a workflow for building and releasing .deb package and the SHA256 checksum of `gls` for Debian-based GNU/Linux distros in order to enable download and install directly from the **Releases** page. 

### Impact

Please delete options that are not relevant.

- [x] New feature (backward compatible change which adds functionality)

### Testing

> Please describe the tests that you ran to verify your changes. Provide step-by-step instructions so anyone can also test your implementation.

**Test Configuration**: 
* Go version: 1.19
* Operating system: Ubuntu 22.04 (GitHub Actions Runner Image)

1. Workflow is triggered when pushing the code with a tag that has semantic version
2. For example: `git tag -a v1.2.3 -m "new version" && git push origin v1.2.3`
3. It can be tested via creating new branch, giving a semver tag and pushing the code with the tag. 